### PR TITLE
set buffer for scanner

### DIFF
--- a/timeplus/client.go
+++ b/timeplus/client.go
@@ -295,9 +295,6 @@ func (s *TimeplusClient) queryStreamV2(sql string, batchCount int, batchBufferTi
 		return nil, nil, fmt.Errorf("failed to create query : %w", err)
 	}
 
-	// scanner := bufio.NewScanner(res.Body)
-	// buf := make([]byte, 0, 64*1024)
-	// scanner.Buffer(buf, 1024*1024)
 	reader := bufio.NewReader(res.Body)
 	ch := make(chan rxgo.Item)
 	canceled := false
@@ -370,10 +367,6 @@ func (s *TimeplusClient) queryStreamV2(sql string, batchCount int, batchBufferTi
 				ch <- rxgo.Of(event)
 			}
 		}
-
-		// if err := scanner.Err(); err != nil {
-		// 	ch <- rxgo.Error(err)
-		// }
 
 		if !canceled {
 			close(ch)

--- a/timeplus/client.go
+++ b/timeplus/client.go
@@ -278,6 +278,8 @@ func (s *TimeplusClient) queryStreamV2(sql string, batchCount int, batchBufferTi
 	}
 
 	scanner := bufio.NewScanner(res.Body)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 1024*1024)
 	ch := make(chan rxgo.Item)
 	canceled := false
 	go func() {

--- a/timeplus/client_test.go
+++ b/timeplus/client_test.go
@@ -19,11 +19,12 @@ func TestClient(t *testing.T) {
 
 	if err != nil {
 		fmt.Printf("Query Failed! %s\n", err)
+		os.Exit(0)
 	}
 
 	fmt.Printf("query result header is, %v\n", ((*queryResult)["result"]).(map[string]any)["header"])
 
-	bufferStream := stream.Take(100000)
+	bufferStream := stream.Take(10)
 	disposed := bufferStream.ForEach(func(v interface{}) {
 		event := v.(*timeplus.DataEvent)
 		fmt.Printf("got one event %v\n", event)


### PR DESCRIPTION
adding buffer for scanner for large query result, now set the buffer to 1M

fix the issue of error `failed to query bufio.Scanner: token too long`