### PR TITLE
Bugfix/16 data lost for the content stream

### DIFF
--- a/timeplus/client_test.go
+++ b/timeplus/client_test.go
@@ -24,7 +24,7 @@ func TestClient(t *testing.T) {
 
 	fmt.Printf("query result header is, %v\n", ((*queryResult)["result"]).(map[string]any)["header"])
 
-	bufferStream := stream.Take(10)
+	bufferStream := stream
 	disposed := bufferStream.ForEach(func(v interface{}) {
 		event := v.(*timeplus.DataEvent)
 		fmt.Printf("got one event %v\n", event)

--- a/timeplus/client_test.go
+++ b/timeplus/client_test.go
@@ -22,7 +22,7 @@ func TestClient(t *testing.T) {
 		os.Exit(0)
 	}
 
-	fmt.Printf("query result header is, %v\n", ((*queryResult)["result"]).(map[string]any)["header"])
+	fmt.Printf("query result header is, %v\n", queryResult.Result.Header)
 
 	bufferStream := stream
 	disposed := bufferStream.ForEach(func(v interface{}) {

--- a/timeplus/client_test.go
+++ b/timeplus/client_test.go
@@ -15,16 +15,16 @@ func TestClient(t *testing.T) {
 	timeplusTenant := os.Getenv("TIMEPLUS_TENANT")
 
 	timeplusClient := timeplus.NewCient(timeplusAddress, timeplusTenant, timeplusApiKey)
-	stream, cancel, queryResult, err := timeplusClient.QueryStream("select * from car_live_data", 100, 128)
+	queryResult, err := timeplusClient.QueryStream("select * from car_live_data", 100, 128)
 
 	if err != nil {
 		fmt.Printf("Query Failed! %s\n", err)
 		os.Exit(0)
 	}
 
-	fmt.Printf("query result header is, %v\n", queryResult.Result.Header)
+	fmt.Printf("query result header is, %v\n", queryResult.Metadata.Result.Header)
 
-	bufferStream := stream
+	bufferStream := queryResult.ResultStream
 	disposed := bufferStream.ForEach(func(v interface{}) {
 		event := v.(*timeplus.DataEvent)
 		fmt.Printf("got one event %v\n", event)
@@ -38,7 +38,7 @@ func TestClient(t *testing.T) {
 		time.Sleep(3 * time.Second)
 		cancel()
 		fmt.Printf("cancel will close the channel for event")
-	}(cancel)
+	}(queryResult.Cancel)
 
 	<-disposed
 


### PR DESCRIPTION
The previous implementation is buggy when handling the header retrieval.
I am updating it with

- return sepcific query as queryInfo struct
- skip all non data event in SSE
- remove some redudant code